### PR TITLE
Don't need citation for training time of logistic regression

### DIFF
--- a/ms.tex
+++ b/ms.tex
@@ -712,8 +712,7 @@ that should be used in the final model.
 In practice, there is something of a trade-off between accuracy and
 computational resources because a larger value of $C_\text{LogReg}$
 will also increase the training time, since a larger $C_\text{LogReg}$
-corresponds to a less constrained parameter space being searched
-\todo{(citation needed)}.
+corresponds to a less constrained parameter space being searched.
 We discuss the performance and training time dependence on $C_\text{LogReg}$
 in Section\ref{sec:regularization}.
 


### PR DESCRIPTION
Don't need citation for training time of logistic regression as a function of regularization parameter.  It appears that it's assumed to be common knowledge in most places.